### PR TITLE
Fixes a Misname for a Retrieve Effect

### DIFF
--- a/docs/docs/effects.md
+++ b/docs/docs/effects.md
@@ -604,7 +604,7 @@ No description provided.
     retrieve [(all|every)] emotes (from|with|of|in) %guild% [(with|using) [the] [bot] %-bot%] and store (them|the emotes) in %-objects%
     ```
 
-## RetrieveEmotes
+## RetrieveInterestedMembers
 
 [[[ macros.required_version('4.0.0') ]]]
 


### PR DESCRIPTION
This PR fixes the naming of a certain retrieve effect which had the same name of the other one above it.